### PR TITLE
Fix for Haxe 3.1.

### DIFF
--- a/src/mcore/exception/Exception.hx
+++ b/src/mcore/exception/Exception.hx
@@ -125,10 +125,8 @@ class Exception
 			switch(stack.shift())
 			{
 				case FilePos(_, file, line): s += "\tat " + file + " (" + line + ")\n";
-				case Module(_):
 				case Method(classname, method): s += "\tat " + classname + "#" + method + "\n";
-				case Lambda(_):
-				case CFunction:
+				default:
 			}
 		}
 		return s;


### PR DESCRIPTION
Lambda was renamed to LocalFunction.  Since it was just ignored anyway, I've lumped it in with `default:`

Passes all unit tests.
