### PR TITLE
Removed attendedToInjectees

### DIFF
--- a/test/minject/ChildInjectorTest.hx
+++ b/test/minject/ChildInjectorTest.hx
@@ -127,23 +127,7 @@ class ChildInjectorTest
 		Assert.isType(robotBody.rightLeg.ankle.foot, RightRobotFoot);
 		Assert.isType(robotBody.leftLeg.ankle.foot, LeftRobotFoot);
 	}
-	
-	@Test
-	public function childInjectorUsesParentsMapOfWorkedInjectees():Void
-	{
-		var childInjector = injector.createChildInjector();
-		
-		var class1 = new Class1();
-		var class2 = new Class1();
 
-		injector.mapValue(Class1, class1);
-		childInjector.mapValue(Class1, class2);
-
-		var injectee = injector.instantiate(ClassInjectee);
-		childInjector.injectInto(injectee);
-		Assert.areEqual(injectee.property, class1);
-	}
-	
     @Test
     public function childInjectorHasMappingWhenExistsOnParentInjector():Void
     {

--- a/test/minject/InjectorTest.hx
+++ b/test/minject/InjectorTest.hx
@@ -652,18 +652,6 @@ class InjectorTest
 		Assert.isTrue(passed);
 	}
 	
-	@Test
-	public function shouldRememberPreviouslyInjectedObjects()
-	{
-		var value = new Class1();
-		injector.mapValue(Class1, value);
-
-		var injectee1 = new ClassInjectee();
-		injector.injectInto(injectee1);
-		
-		Assert.isTrue(injector.attendedToInjectees.contains(injectee1));
-	}
-	
 	#if cpp
 		#if (!haxe_210 && (haxe_208||haxe_209))
 		@Ignore("Not supported in Haxe 2.08 or Haxe 2.09")


### PR DESCRIPTION
@thomasuster unfortunately I had to roll back some of your optimisations as the changes to parent injectors/ancestor mappings had broken a number of things on one of our largest codebases. I spent a good four hours trying to track it down, but didn't have any luck. I think the main problem were subtle differences in the previous getMapping (which would get if existed, including ancestors) or create, and the new one which generally assumed the mapping existed already. Caching the requestName also created problems where an injection point was the first to ask for a mapping, ie. getConfig(requestName) was returning null depending on what you had done to your injector up to that point.

Happy to take a look at some of the optimisations again in a separate PR, but lets try smaller ones so we can carefully track and think through how the changes affect more complex scenarios.