### PR TITLE
V2 fix: Read superclass injection points

### DIFF
--- a/src/minject/InjectorMacro.hx
+++ b/src/minject/InjectorMacro.hx
@@ -81,7 +81,7 @@ class InjectorMacro
 		{
 			case TType(_, _):
 				var expr = expr.toString();
-				var type = Context.getType(expr).toString();
+				var type = Context.getType(expr).follow().toString();
 				macro $v{type};
 			case _:
 				expr;
@@ -175,7 +175,7 @@ class InjectorMacro
 		{
 			case FVar(_, _):
 				keep.set('set_' + field.name, true);
-				rtti.push(field.type.toString());
+				rtti.push(field.type.follow().toString());
 				if (names.length > 0) rtti.push(names[0].getValue());
 				else rtti.push('');
 			case FMethod(_):
@@ -185,7 +185,7 @@ class InjectorMacro
 						for (i in 0...args.length)
 						{
 							var arg = args[i];
-							rtti.push(arg.t.toString());
+							rtti.push(arg.t.follow().toString());
 							rtti.push(names[i] == null ? '' : names[i].getValue());
 							rtti.push(arg.opt ? 'o' : '');
 						}

--- a/test/minject/InjectorTest.hx
+++ b/test/minject/InjectorTest.hx
@@ -26,6 +26,7 @@ import massive.munit.Assert;
 import minject.Injector;
 import minject.support.injectees.ClassInjectee;
 import minject.support.injectees.InheritanceInjectee;
+import minject.support.injectees.TypedefInjectee;
 import minject.support.injectees.InterfaceInjectee;
 import minject.support.injectees.NamedClassInjectee;
 import minject.support.injectees.NamedInterfaceInjectee;
@@ -217,6 +218,21 @@ import minject.support.injectees.RecursiveInjectee;
 		Assert.isTrue(injectee1.extraProperty);
 		Assert.isFalse(injectee1.property == injectee2.property);
 		Assert.isFalse(injectee1.property2 == injectee2.property2);
+	}
+
+	@Test
+	public function bindTypedef():Void
+	{
+		injector.mapClass(Typedef1, Typedef1);
+		injector.mapClass(TypedefInjectee, TypedefInjectee);
+
+		Assert.isTrue(injector.hasRule(Typedef1));
+		Assert.isTrue(injector.hasRule(Class1));
+
+		var injectee1 = new TypedefInjectee();
+		injector.injectInto(injectee1);
+
+		Assert.isNotNull(injectee1.property);
 	}
 
 	@Test

--- a/test/minject/InjectorTest.hx
+++ b/test/minject/InjectorTest.hx
@@ -25,6 +25,7 @@ package minject;
 import massive.munit.Assert;
 import minject.Injector;
 import minject.support.injectees.ClassInjectee;
+import minject.support.injectees.InheritanceInjectee;
 import minject.support.injectees.InterfaceInjectee;
 import minject.support.injectees.NamedClassInjectee;
 import minject.support.injectees.NamedInterfaceInjectee;
@@ -196,6 +197,26 @@ import minject.support.injectees.RecursiveInjectee;
 
 		Assert.isNotNull(injectee1.property);
 		Assert.isFalse(injectee1.property == injectee2.property);
+	}
+
+	@Test
+	public function bindInheritedClass():Void
+	{
+		injector.mapClass(Class1, Class1);
+		injector.mapClass(Class2, Class2);
+
+		var injectee1 = new InheritanceInjectee();
+		injector.injectInto(injectee1);
+
+		var injectee2 = new InheritanceInjectee();
+		injector.injectInto(injectee2);
+
+		Assert.isNotNull(injectee1.property);
+		Assert.isNotNull(injectee1.property2);
+		Assert.isTrue(injectee1.someProperty);
+		Assert.isTrue(injectee1.extraProperty);
+		Assert.isFalse(injectee1.property == injectee2.property);
+		Assert.isFalse(injectee1.property2 == injectee2.property2);
 	}
 
 	@Test

--- a/test/minject/support/injectees/InheritanceInjectee.hx
+++ b/test/minject/support/injectees/InheritanceInjectee.hx
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2012-2015 Massive Interactive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package minject.support.injectees;
+
+import minject.support.types.Class1;
+import minject.support.types.Class2;
+
+class InheritanceInjectee extends ClassInjectee
+{
+	@inject
+	public var property2:Class2;
+
+	public var extraProperty:Bool;
+
+	public function new()
+	{
+		super();
+		extraProperty = false;
+	}
+
+	@post(2)
+	public function doExtraStuff():Void
+	{
+		extraProperty = true;
+	}
+}

--- a/test/minject/support/injectees/TypedefInjectee.hx
+++ b/test/minject/support/injectees/TypedefInjectee.hx
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2012-2015 Massive Interactive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package minject.support.injectees;
+
+import minject.support.types.Class1;
+
+class TypedefInjectee
+{
+	@inject
+	public var property:Typedef1;
+
+	public var someProperty:Bool;
+
+	public function new()
+	{
+		someProperty = false;
+	}
+
+	@post(1)
+	public function doSomeStuff():Void
+	{
+		someProperty = true;
+	}
+}
+
+typedef Typedef1 = Class1;


### PR DESCRIPTION
This is something that worked in 1.*, but not in the v2 fork.  I've added a test to check it works.