### PR TITLE
(V2) Fallback to `Array#name` if rule for `Array<String>#name` is not found.

### DIFF
--- a/src/minject/InjectorMacro.hx
+++ b/src/minject/InjectorMacro.hx
@@ -81,7 +81,7 @@ class InjectorMacro
 		{
 			case TType(_, _):
 				var expr = expr.toString();
-				var type = Context.getType(expr).toString();
+				var type = Context.getType(expr).follow().toString();
 				macro $v{type};
 			case _:
 				expr;
@@ -175,7 +175,7 @@ class InjectorMacro
 		{
 			case FVar(_, _):
 				keep.set('set_' + field.name, true);
-				rtti.push(field.type.toString());
+				rtti.push(field.type.follow().toString());
 				if (names.length > 0) rtti.push(names[0].getValue());
 				else rtti.push('');
 			case FMethod(_):
@@ -185,7 +185,7 @@ class InjectorMacro
 						for (i in 0...args.length)
 						{
 							var arg = args[i];
-							rtti.push(arg.t.toString());
+							rtti.push(arg.t.follow().toString());
 							rtti.push(names[i] == null ? '' : names[i].getValue());
 							rtti.push(arg.opt ? 'o' : '');
 						}

--- a/src/minject/InjectorMacro.hx
+++ b/src/minject/InjectorMacro.hx
@@ -82,7 +82,9 @@ class InjectorMacro
 			case TType(_, _):
 				var expr = expr.toString();
 				var type = Context.getType(expr).follow().toString();
-				macro $v{type};
+				var index = type.indexOf("<");
+				var typeWithoutParams = (index>-1) ? type.substr(0, index) : type;
+				macro $v{typeWithoutParams};
 			case _:
 				expr;
 		}

--- a/src/minject/point/MethodInjectionPoint.hx
+++ b/src/minject/point/MethodInjectionPoint.hx
@@ -59,15 +59,20 @@ class MethodInjectionPoint implements InjectionPoint
 			var argName = args[index++];
 			var opt = args[index++] == 'o';
 
-			var rule = injector.getTypeRule(type, argName);
-			var response = rule.getResponse(injector);
+			var response = injector.getTypeRule(type, argName).getResponse(injector);
+			if (response == null)
+			{
+				var index = type.indexOf("<");
+				type = (index>-1) ? type.substr(0, index) : type;
+				response = injector.getTypeRule(type, argName).getResponse(injector);
+			}
 
 			#if debug
 			if (response == null && !opt)
 			{
 				var targetName = Type.getClassName(Type.getClass(target));
 				throw 'Injector is missing a rule to handle injection into ' +
-					'target "$targetName". Target dependency: "${rule.type}", ' +
+					'target "$targetName". Target dependency: "$type", ' +
 					'method: "$name", named: "$argName"';
 			}
 			#end

--- a/src/minject/point/PropertyInjectionPoint.hx
+++ b/src/minject/point/PropertyInjectionPoint.hx
@@ -40,6 +40,12 @@ class PropertyInjectionPoint implements InjectionPoint
 	public function applyInjection(target:Dynamic, injector:Injector):Dynamic
 	{
 		var response = injector.getTypeRule(type, injectionName).getResponse(injector);
+		if (response == null)
+		{
+			var index = type.indexOf("<");
+			type = (index>-1) ? type.substr(0, index) : type;
+			response = injector.getTypeRule(type, injectionName).getResponse(injector);
+		}
 
 		#if debug
 		if (response == null)

--- a/test/minject/InjectorTest.hx
+++ b/test/minject/InjectorTest.hx
@@ -26,6 +26,7 @@ import massive.munit.Assert;
 import minject.Injector;
 import minject.support.injectees.ClassInjectee;
 import minject.support.injectees.InheritanceInjectee;
+import minject.support.injectees.TypedefInjectee;
 import minject.support.injectees.InterfaceInjectee;
 import minject.support.injectees.NamedClassInjectee;
 import minject.support.injectees.NamedInterfaceInjectee;
@@ -217,6 +218,21 @@ import minject.support.injectees.RecursiveInjectee;
 		Assert.isTrue(injectee1.extraProperty);
 		Assert.isFalse(injectee1.property == injectee2.property);
 		Assert.isFalse(injectee1.property2 == injectee2.property2);
+	}
+
+	@Test
+	public function bindTypedef():Void
+	{
+		injector.mapClass(Typedef1, Typedef1);
+		injector.mapClass(TypedefInjectee, TypedefInjectee);
+
+		Assert.isTrue(injector.hasRule(Typedef1));
+		Assert.isTrue(injector.hasRule(Class1));
+
+		var injectee1 = new TypedefInjectee();
+		injector.injectInto(injectee1);
+
+		Assert.isNotNull(injectee1.property);
 	}
 
 	@Test

--- a/test/minject/InjectorTest.hx
+++ b/test/minject/InjectorTest.hx
@@ -25,6 +25,7 @@ package minject;
 import massive.munit.Assert;
 import minject.Injector;
 import minject.support.injectees.ClassInjectee;
+import minject.support.injectees.InheritanceInjectee;
 import minject.support.injectees.InterfaceInjectee;
 import minject.support.injectees.NamedClassInjectee;
 import minject.support.injectees.NamedInterfaceInjectee;
@@ -196,6 +197,26 @@ import minject.support.injectees.RecursiveInjectee;
 
 		Assert.isNotNull(injectee1.property);
 		Assert.isFalse(injectee1.property == injectee2.property);
+	}
+
+	@Test
+	public function bindInheritedClass():Void
+	{
+		injector.mapClass(Class1, Class1);
+		injector.mapClass(Class2, Class2);
+
+		var injectee1 = new InheritanceInjectee();
+		injector.injectInto(injectee1);
+
+		var injectee2 = new InheritanceInjectee();
+		injector.injectInto(injectee2);
+
+		Assert.isNotNull(injectee1.property);
+		Assert.isNotNull(injectee1.property2);
+		Assert.isTrue(injectee1.someProperty);
+		Assert.isTrue(injectee1.extraProperty);
+		Assert.isFalse(injectee1.property == injectee2.property);
+		Assert.isFalse(injectee1.property2 == injectee2.property2);
 	}
 
 	@Test

--- a/test/minject/InjectorTest.hx
+++ b/test/minject/InjectorTest.hx
@@ -27,6 +27,7 @@ import minject.Injector;
 import minject.support.injectees.ClassInjectee;
 import minject.support.injectees.InheritanceInjectee;
 import minject.support.injectees.TypedefInjectee;
+import minject.support.injectees.TypeParamInjectee;
 import minject.support.injectees.InterfaceInjectee;
 import minject.support.injectees.NamedClassInjectee;
 import minject.support.injectees.NamedInterfaceInjectee;
@@ -233,6 +234,25 @@ import minject.support.injectees.RecursiveInjectee;
 		injector.injectInto(injectee1);
 
 		Assert.isNotNull(injectee1.property);
+	}
+
+	@Test
+	public function bindTypeParams():Void
+	{
+		// These 2 rules should match on the full type, so do not need a name.
+		injector.mapValue("Array<String>", ["Jason","David"]);
+		injector.mapValue("Array<Int>", [0,1,2]);
+		// These 2 rules should match an Array with any type parameter - hence the need for names.
+		injector.mapValue(Array, ["London","Sydney","Perth"], "cities");
+		injector.mapValue(Array, [8416535,4840600,2021200], "populations");
+
+		var injectee = new TypeParamInjectee();
+		injector.injectInto(injectee);
+
+		Assert.areEqual("Jason", injectee.names[0]);
+		Assert.areEqual(0, injectee.numbers[0]);
+		Assert.areEqual("London", injectee.cities[0]);
+		Assert.areEqual(8416535, injectee.populations[0]);
 	}
 
 	@Test

--- a/test/minject/support/injectees/InheritanceInjectee.hx
+++ b/test/minject/support/injectees/InheritanceInjectee.hx
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2012-2015 Massive Interactive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package minject.support.injectees;
+
+import minject.support.types.Class1;
+import minject.support.types.Class2;
+
+class InheritanceInjectee extends ClassInjectee
+{
+	@inject
+	public var property2:Class2;
+
+	public var extraProperty:Bool;
+
+	public function new()
+	{
+		super();
+		extraProperty = false;
+	}
+
+	@post(2)
+	public function doExtraStuff():Void
+	{
+		extraProperty = true;
+	}
+}

--- a/test/minject/support/injectees/TypeParamInjectee.hx
+++ b/test/minject/support/injectees/TypeParamInjectee.hx
@@ -1,0 +1,47 @@
+/*
+Copyright (c) 2012-2015 Massive Interactive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package minject.support.injectees;
+
+import minject.support.types.Class1;
+
+class TypeParamInjectee
+{
+	@inject
+	public var names:Array<String>;
+
+	@inject
+	public var numbers:Array<Int>;
+
+	@inject("cities")
+	public var cities:Array<String>;
+
+	@inject("populations")
+	public var populations:Array<Int>;
+
+	@inject('','','cities','populations')
+	public function testMethodInjection(names:Array<String>, numbers:Array<Int>, cities:Array<String>, populations:Array<Int>) {
+		// Just test that no exception is thrown.
+	}
+
+	public function new() {}
+}

--- a/test/minject/support/injectees/TypedefInjectee.hx
+++ b/test/minject/support/injectees/TypedefInjectee.hx
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2012-2015 Massive Interactive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package minject.support.injectees;
+
+import minject.support.types.Class1;
+
+class TypedefInjectee
+{
+	@inject
+	public var property:Typedef1;
+
+	public var someProperty:Bool;
+
+	public function new()
+	{
+		someProperty = false;
+	}
+
+	@post(1)
+	public function doSomeStuff():Void
+	{
+		someProperty = true;
+	}
+}
+
+typedef Typedef1 = Class1;


### PR DESCRIPTION
This means that you can be precise if you want:

    injector.mapValue( "Array<String>", [] );

Or you can just ignore type params:

    injector.mapValue( Array, [] );

This avoids some runtime code breakages between v1 and v2, and I imagine it would be a common pitfall with the new usage.

(Please note this includes the commits in #39, so it might be better to address that pull request first before accepting this one.)