### PR TITLE
Fix: childInjector.getResponse(...) created blank rule.

### DIFF
--- a/src/minject/Injector.hx
+++ b/src/minject/Injector.hx
@@ -359,13 +359,17 @@ class Injector
 
 	public function getTypeResponse(forType:String, ?named:String):Dynamic
 	{
-		var response = getTypeRule(forType, named).getResponse(this);
+		var rule = getRuleForRequest(forType, named, true);
+		var response = (rule!=null) ? rule.getResponse(this) : null;
+
 		if (response == null)
 		{
 			// if Array<Int> fails fall back to Array
 			var index = forType.indexOf("<");
-			if (index > -1)
-				response = getTypeRule(forType.substr(0, index), named).getResponse(this);
+			if (index > -1) {
+				rule = getRuleForRequest(forType.substr(0, index), named);
+				response = (rule!=null) ? rule.getResponse(this) : null;
+			}
 		}
 		return response;
 	}

--- a/src/minject/InjectorRule.hx
+++ b/src/minject/InjectorRule.hx
@@ -50,7 +50,13 @@ class InjectorRule
 
 	public function hasResponse(injector:Injector):Bool
 	{
-		return result != null;
+		if (this.injector != null) injector = this.injector;
+		if (result != null) return true;
+
+		var parent = injector.getAncestorRule(type, injectionName);
+		if (parent != null && parent.result != null) return true;
+
+		return false;
 	}
 
 	public function hasOwnResponse():Bool

--- a/test/minject/ChildInjectorTest.hx
+++ b/test/minject/ChildInjectorTest.hx
@@ -129,35 +129,55 @@ import minject.support.types.Class1;
 		Assert.isType(robotBody.leftLeg.ankle.foot, LeftRobotFoot);
 	}
 
-    @Test
-    public function child_injector_has_mapping_when_exists_on_parent_injector():Void
-    {
-        var childInjector = injector.createChildInjector();
-        var class1 = new Class1();
-        injector.mapValue(Class1, class1);
+	@Test
+	public function child_injector_has_mapping_when_exists_on_parent_injector():Void
+	{
+		var childInjector = injector.createChildInjector();
+		var class1 = new Class1();
+		injector.mapValue(Class1, class1);
 
-        Assert.isTrue(childInjector.hasRule(Class1));
-    }
+		Assert.isTrue(childInjector.hasRule(Class1));
+	}
 
-    @Test
-    public function child_injector_does_not_have_mapping_when_does_not_exist_on_parent_injector():Void
-    {
-        var childInjector = injector.createChildInjector();
-        Assert.isFalse(childInjector.hasRule(Class1));
-    }
+	@Test
+	@:access(minject.Injector)
+	public function child_injector_get_response_does_not_break_mapping_when_when_exists_on_parent_injector():Void
+	{
+		var childInjector = injector.createChildInjector();
+		var class1 = new Class1();
+		injector.mapValue(Class1, class1);
 
-    @Test
-    public function grand_child_injector_supplies_injection_from_ancestor():Void
-    {
-        var injectee = new ClassInjectee();
-        var childInjector = injector.createChildInjector();
-        var grandChildInjector = childInjector.createChildInjector();
+		Assert.areEqual(1, Lambda.count(injector.rules));
+		Assert.areEqual(0, Lambda.count(childInjector.rules));
 
-        injector.mapSingleton(Class1);
-        grandChildInjector.injectInto(injectee);
+		var response1 = childInjector.getResponse(Class1);
+		var response2 = childInjector.getInstance(Class1);
+		Assert.areEqual( class1, response1 );
+		Assert.areEqual( class1, response2 );
 
-        Assert.isType(injectee.property, Class1);
-    }
+		Assert.areEqual(1, Lambda.count(injector.rules));
+		Assert.areEqual(0, Lambda.count(childInjector.rules));
+	}
+
+	@Test
+	public function child_injector_does_not_have_mapping_when_does_not_exist_on_parent_injector():Void
+	{
+		var childInjector = injector.createChildInjector();
+		Assert.isFalse(childInjector.hasRule(Class1));
+	}
+
+	@Test
+	public function grand_child_injector_supplies_injection_from_ancestor():Void
+	{
+		var injectee = new ClassInjectee();
+		var childInjector = injector.createChildInjector();
+		var grandChildInjector = childInjector.createChildInjector();
+
+		injector.mapSingleton(Class1);
+		grandChildInjector.injectInto(injectee);
+
+		Assert.isType(injectee.property, Class1);
+	}
 
 	@Test
 	public function can_create_child_injector_during_injection():Void


### PR DESCRIPTION
As a result,

	parentInjector.mapValue( String, "Hello" );
	childInjector.getResponse( String ); // This call works, but creates a rule on the child injector which breaks further calls.
	childInjector.getInstance( String ); // No rule defined for class "String" named "null"

I've created some unit tests.

Please note they use @:access(minject.Injector) so I can check if a rule exists ONLY on the parent injector, not the child injector. Merely testing the code above did not guarantee that the rule (with a null result) was not created on the child injector.