### PR TITLE
Added breaking tests for anonymous typedef mapping

### DIFF
--- a/src/test/minject/InjectorTest.hx
+++ b/src/test/minject/InjectorTest.hx
@@ -6,6 +6,7 @@ import Type;
 
 import massive.munit.Assert;
 import minject.support.injectees.*;
+import minject.support.injectees.AnonTypedefInjectee;
 import minject.support.injectees.TypedefInjectee;
 import minject.support.injectees.RecursiveInjectee;
 import minject.support.types.*;
@@ -291,6 +292,65 @@ import minject.support.types.*;
 		Assert.isTrue(Std.is(injectee.property1, Class1));
 		Assert.isTrue(Std.is(injectee.property2, Class2));
 		Assert.isFalse(injectee.property1 == injectee.property2);
+	}
+
+	@Test
+	public function bind_anonymous_structure_typedef():Void
+	{
+		var injectee = new AnonTypedefInjectee();
+
+		var myGreeter:Greeter = {
+			name:"world", 
+			hello:function(name) {
+				return "hello " + name;
+			}
+		};
+
+		injector.map(Greeter).toValue(myGreeter);
+
+		injector.injectInto(injectee);
+
+		Assert.isNotNull(injectee.property);
+	}
+
+	@Test
+	public function bind_anonymous_structure_typedef_by_reference():Void
+	{
+		var injectee = new AnonTypedefInjectee();
+
+		var myGreeter:Greeter = {
+			name:"world", 
+			hello:function(name) {
+				return "hello " + name;
+			}
+		};
+
+		injector.map(myGreeter).toValue(myGreeter);
+
+		injector.injectInto(injectee);
+
+		Assert.isNotNull(injectee.property);
+	}
+
+	@Test
+	public function bind_anonymous_structure_typedef_by_fieds_string():Void
+	{
+		var injectee = new AnonTypedefInjectee();
+
+		var myGreeter:Greeter = {
+			name:"world", 
+			hello:function(name) {
+				return "hello " + name;
+			}
+		};
+
+		var greeter = "minject.support.injectees.Greeter";
+
+		injector.map(greeter).toValue(myGreeter);
+
+		injector.injectInto(injectee);
+
+		Assert.isNotNull(injectee.property);
 	}
 
 	@Test

--- a/src/test/minject/support/injectees/AnonTypedefInjectee.hx
+++ b/src/test/minject/support/injectees/AnonTypedefInjectee.hx
@@ -1,0 +1,27 @@
+// See the file "LICENSE" for the full license governing this code
+
+package minject.support.injectees;
+
+import minject.support.types.Class1;
+
+class AnonTypedefInjectee
+{
+	@inject
+	public var property:Greeter;
+
+	public function new()
+	{
+	}
+
+	@post(1)
+	public function sayHi():Void
+	{
+		trace(property.hello(property.name));
+	}
+
+}
+
+typedef Greeter = {
+	var name:String;
+	public function hello(name:String):String;
+};


### PR DESCRIPTION
The first two tests are actually breaking the compilation, complaining that "minject.support.injectees.Greeter is not a value" and "minject.support.injectees.Greeter should be String"

The first test shows what would be the preferable syntax
The second one was added because suggested here https://github.com/massiveinteractive/minject/issues/45#issuecomment-108808931
The third test shows what works right now, which is not too bad after all ...
