### PR TITLE
Fix post ordering when using super classes.

### DIFF
--- a/src/lib/minject/point/PostInjectionPoint.hx
+++ b/src/lib/minject/point/PostInjectionPoint.hx
@@ -1,0 +1,17 @@
+// See the file "LICENSE" for the full license governing this code
+
+package minject.point;
+
+import minject.Injector;
+import minject.point.MethodInjectionPoint;
+
+class PostInjectionPoint extends MethodInjectionPoint
+{
+	public var order(default, null):Int;
+
+	public function new(field:String, args:Array<String>, order:Int)
+	{
+		super(field, args);
+		this.order = order;
+	}
+}


### PR DESCRIPTION
The previous implementation ordered them per-class at compiletime,
and so failed to execute them in the correct order when there were
injection points on both the current class and the super class.

This implementation adds the `PostInjectionPoint` class, which has
the order included, and sorts the fields at runtime *after* all
injection points from super-classes have been loaded.

Fixes #49.
