### PR TITLE
fixing injections of nested typedefs

### DIFF
--- a/src/minject/Macro.hx
+++ b/src/minject/Macro.hx
@@ -92,6 +92,16 @@ class Macro
 				{
 					case TType(t, _):
 						var def = t.get();
+						
+						while(true)
+							switch(def.type)
+							{
+								case TType(t, _): 
+									def = t.get();
+								default:
+									break;
+							}
+						
 						switch (def.type)
 						{
 							case TInst(t, params):

--- a/test/minject/InjectorTest.hx
+++ b/test/minject/InjectorTest.hx
@@ -49,9 +49,12 @@ import minject.support.injectees.XMLInjectee;
 import minject.support.injectees.OrderedPostConstructInjectee;
 import minject.support.types.Class1;
 import minject.support.types.Class2;
+import minject.support.types.Class3;
 import minject.support.types.Interface1;
 import minject.support.types.Interface2;
 import minject.support.types.ComplexClass;
+import minject.support.types.TypedefToClass1;
+import minject.support.types.TypedefToTypedefToClass1;
 import minject.support.injectees.SetterInjectee;
 import minject.support.injectees.RecursiveInjectee;
 
@@ -492,6 +495,17 @@ class InjectorTest
 		//Assert.areEqual(injectee.property1, injectee.property2);//"Instance field 'property1' should be identical to Instance field 'property2'"
 		//Assert.areEqual(injectee.property1, injectee.namedProperty1);//"Instance field 'property1' should be identical to Instance field 'namedProperty1'"
 		//Assert.areEqual(injectee.property1, injectee.namedProperty2);//"Instance field 'property1' should be identical to Instance field 'namedProperty2'"
+	}
+	
+	@Test
+	public function performNestedTypedefInjection():Void
+	{
+		var injectee = new Class3();
+		var injector = new Injector();
+		injector.mapSingleton(TypedefToTypedefToClass1);
+		injector.injectInto(injectee);
+		
+		Assert.isTrue(Std.is(injectee.value, Class1));
 	}
 	
 	@Test

--- a/test/minject/support/types/Class3.hx
+++ b/test/minject/support/types/Class3.hx
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2012-2014 Massive Interactive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights to 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is furnished to do 
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.
+*/
+
+package minject.support.types;
+
+class Class3
+{
+	@inject
+	public var value:TypedefToTypedefToClass1;
+
+	public function new() {}
+}

--- a/test/minject/support/types/TypedefToClass1.hx
+++ b/test/minject/support/types/TypedefToClass1.hx
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2012-2014 Massive Interactive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights to 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is furnished to do 
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.
+*/
+
+package minject.support.types;
+
+typedef TypedefToClass1 = Class1;

--- a/test/minject/support/types/TypedefToTypedefToClass1.hx
+++ b/test/minject/support/types/TypedefToTypedefToClass1.hx
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2012-2014 Massive Interactive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights to 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is furnished to do 
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.
+*/
+
+package minject.support.types;
+
+typedef TypedefToTypedefToClass1 = TypedefToClass1;


### PR DESCRIPTION
this is a fix for injecting nested typedef-s done on top of version 1.6.1, wish for 1.6.2 but not an easy way to make PR on top of it

solving something like this
```
class A
typedef A1 = A;
typedef A2 = A1;

class B {
	@inject public var a:A2;
}
```

