### PR TITLE
Added injector.parent set

### DIFF
--- a/src/lib/minject/Injector.hx
+++ b/src/lib/minject/Injector.hx
@@ -38,7 +38,7 @@ class Injector
 	/**
 		The parent of this injector
 	**/
-	public var parent(default, null):Injector;
+	public var parent:Injector;
 
 	// map of injector mappings by type#name
 	var mappings = new Map<String, InjectorMapping<Dynamic>>();


### PR DESCRIPTION
I don't see any issue with being able to replace the parent injector.

I've implemented the `minject.Injector` into a robotlegs fork and this is the only modification I need. I'm planning to open source my RL fork in the near future and it would be great to have this PR merged as I'm making minject v2 a hard dependency.